### PR TITLE
feat: ULIDField を python-ulid / ulid-py 両対応にし system check を追加

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,12 @@ Repository = "https://github.com/yk-lab/ya-django-toolkit-jp"
 Documentation = "https://github.com/yk-lab/ya-django-toolkit-jp"
 
 # オプション依存（コアは Django のみで動作する）。
-# ※ ulid-py / django-boost の扱いは #15 / #16 で変更予定。ここでは現状維持。
+# ULID は推奨の保守版 python-ulid を `[all]` に入れる。コードは ulid-py も
+# 後方互換で受け付けるため、既存ユーザーがそのまま ulid-py を継続使用しても動作する。
+# ※ django-boost は #15 でインライン撤廃予定。
 [project.optional-dependencies]
 all = [
-    "ulid-py>=1.1.0,<2.0",
+    "python-ulid>=3.0,<4.0",
     "django-boost>=2.1,<3.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -472,6 +472,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-ulid"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/7e/0d6c82b5ccc71e7c833aed43d9e8468e1f2ff0be1b3f657a6fcafbb8433d/python_ulid-3.1.0.tar.gz", hash = "sha256:ff0410a598bc5f6b01b602851a3296ede6f91389f913a5d5f8c496003836f636", size = 93175, upload-time = "2025-08-18T16:09:26.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/a0/4ed6632b70a52de845df056654162acdebaf97c20e3212c559ac43e7216e/python_ulid-3.1.0-py3-none-any.whl", hash = "sha256:e2cdc979c8c877029b4b7a38a6fba3bc4578e4f109a308419ff4d3ccf0a46619", size = 11577, upload-time = "2025-08-18T16:09:25.047Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -583,15 +592,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ulid-py"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3b/53/d14a8ec344048e21431821cb49e9a6722384f982b889c2dd449428dbdcc1/ulid-py-1.1.0.tar.gz", hash = "sha256:dc6884be91558df077c3011b9fb0c87d1097cb8fc6534b11f310161afd5738f0", size = 22514, upload-time = "2020-09-15T15:35:09.414Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/7c/a12c879fe6c2b136a718c142115ff99397fbf62b4929d970d58ae386d55f/ulid_py-1.1.0-py2.py3-none-any.whl", hash = "sha256:b56a0f809ef90d6020b21b89a87a48edc7c03aea80e5ed5174172e82d76e3987", size = 25753, upload-time = "2020-09-15T15:35:08.075Z" },
-]
-
-[[package]]
 name = "user-agents"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -628,7 +628,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "django-boost" },
-    { name = "ulid-py" },
+    { name = "python-ulid" },
 ]
 
 [package.dev-dependencies]
@@ -649,7 +649,7 @@ dev = [
 requires-dist = [
     { name = "django", specifier = ">=4.2,<5.0" },
     { name = "django-boost", marker = "extra == 'all'", specifier = ">=2.1,<3.0" },
-    { name = "ulid-py", marker = "extra == 'all'", specifier = ">=1.1.0,<2.0" },
+    { name = "python-ulid", marker = "extra == 'all'", specifier = ">=3.0,<4.0" },
 ]
 provides-extras = ["all"]
 

--- a/ya_django_toolkit_jp/fields/ulid.py
+++ b/ya_django_toolkit_jp/fields/ulid.py
@@ -1,27 +1,67 @@
+from django.core import checks
 from django.db import models
 
+# ULID バックエンドは python-ulid（保守版・推奨）と ulid-py（後方互換）の両対応。
+# 両者は同じ `ulid` モジュール名を占有するため一環境に同居不可。実行時判別する。
 try:
-    from ulid import providers
-    from ulid.api import api
+    import ulid as _ulid
 except ImportError:
-    providers = None
-    api = None
+    _ulid = None
 
 
 def default():
-    if not providers or not api:
-        raise ImportError('ULIDField requires ulid package.')
+    """ULID をベースに `uuid.UUID` を生成する（`UUIDField` 互換）。
 
-    ulid_api = api.Api(providers.DEFAULT)
-    return ulid_api.new().uuid
+    インストールされているバックエンドを実行時判別:
+      - ulid-py: `ulid.api` 属性を持つ → `api.Api(providers.DEFAULT).new().uuid`
+      - python-ulid: それ以外 → `ulid.ULID().to_uuid()`
+
+    両バックエンド未インストール時は `ImportError`（最終防壁）。通常はモデル定義時に
+    `ULIDField.check()` が `ya_django_toolkit_jp.E001` として通知する。
+    """
+    if _ulid is None:
+        raise ImportError(
+            'ULIDField requires the `python-ulid` package (recommended) '
+            'or `ulid-py` (legacy). '
+            'Install with: pip install ya-django-toolkit-jp[all]'
+        )
+    if hasattr(_ulid, 'api'):
+        # ulid-py 後方互換パス
+        from ulid import providers
+        from ulid.api import api
+        return api.Api(providers.DEFAULT).new().uuid
+    # python-ulid（推奨）
+    return _ulid.ULID().to_uuid()
 
 
 class ULIDField(models.UUIDField):
-    def __init__(self, primary_key=True, editable=False, *args, **kwargs):
-        if not providers or not api:
-            raise ImportError('ULIDField requires ulid package.')
+    """ULID をベースに UUID として保存するフィールド。
 
+    モデルへの追加・import 時点では ulid バックエンド未インストールでもフィールドは
+    構築できる（Django 標準の `ImageField` が Pillow 未導入時に `check()` で通知する
+    のと同じ方式）。`manage.py check` が `ya_django_toolkit_jp.E001` で通知し、
+    実際に値生成しようとすると `default()` が分かりやすい `ImportError` を出す。
+    """
+
+    def __init__(self, primary_key=True, editable=False, *args, **kwargs):
         kwargs.setdefault('primary_key', primary_key)
         kwargs.setdefault('editable', editable)
         kwargs.setdefault('default', default)
         super().__init__(*args, **kwargs)
+
+    def check(self, **kwargs):
+        return [*super().check(**kwargs), *self._check_ulid_backend()]
+
+    def _check_ulid_backend(self):
+        if _ulid is None:
+            return [
+                checks.Error(
+                    'ULIDField を使うには ulid バックエンドが必要です'
+                    '（python-ulid 推奨 / ulid-py も可）。',
+                    hint='pip install ya-django-toolkit-jp[all]  '
+                         '（または: pip install python-ulid）でインストールしてください。',
+                    obj=self,
+                    id='ya_django_toolkit_jp.E001',
+                )
+            ]
+        return []


### PR DESCRIPTION
## 概要
Issue #16 の実装。`ULIDField` を **python-ulid（推奨）と ulid-py（後方互換）の両対応**にし、依存未インストール時の挙動を Django 標準の system check 方式（`ImageField`/Pillow と同じ）へ刷新。

## 変更点

### コード
- `default()`: 実行時にバックエンド判別
  - `hasattr(ulid, 'api')` → ulid-py 経路（`api.Api(providers.DEFAULT).new().uuid`）
  - それ以外 → python-ulid 経路（`ULID().to_uuid()`）
- `ULIDField.__init__`: 即時 `ImportError` を撤廃。**モデル定義時はバックエンド未インストールでもフィールド構築可能**
- `ULIDField.check()` を追加: 両バックエンド未インストール時に `ya_django_toolkit_jp.E001` を報告
- `default()` は実行時の最終防壁として `ImportError` を残す（メッセージにインストール手順をヒント）

### 依存
- `[project.optional-dependencies].all` を `ulid-py` → **`python-ulid>=3.0,<4.0`**（保守版）に更新
- ただしコードは ulid-py が入っていても動くため、**既存 ulid-py ユーザーは無変更で継続使用可**

## 後方互換
- `default` callable の dotted path（`ya_django_toolkit_jp.fields.ulid.default`）を維持 → downstream の `AlterField` マイグレーション churn 無し
- DB 格納形式は UUID のまま（ULID 値はもともとランダムなので既存行への影響なし）

## 実証検証（3シナリオ・ephemeral 環境）

| シナリオ | backend | import | `check()` | `default()` |
|---|---|---|---|---|
| python-ulid only | python-ulid | ✅ | `[]` | ✅ UUID |
| ulid-py only | ulid-py | ✅ | `[]` | ✅ UUID |
| どちらも無し | NONE | **✅（落ちない）** | `[E001]` | clear `ImportError` + install hint |

加えて既存テスト 8件は dev 環境（python-ulid 入）で green。

## 引き継ぎ
- CI で**両バックエンドを最低 1 ジョブずつ検証**することは #06（nox マトリクス）で実施。

Closes #16
Refs #06

🤖 Generated with [Claude Code](https://claude.com/claude-code)
