### PR TITLE
refactor: django-boost 依存を撤廃し mixin をインライン化

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,9 @@ Documentation = "https://github.com/yk-lab/ya-django-toolkit-jp"
 # オプション依存（コアは Django のみで動作する）。
 # ULID は推奨の保守版 python-ulid を `[all]` に入れる。コードは ulid-py も
 # 後方互換で受け付けるため、既存ユーザーがそのまま ulid-py を継続使用しても動作する。
-# ※ django-boost は #15 でインライン撤廃予定。
 [project.optional-dependencies]
 all = [
     "python-ulid>=3.0,<4.0",
-    "django-boost>=2.1,<3.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -159,19 +159,6 @@ wheels = [
 ]
 
 [[package]]
-name = "django-boost"
-version = "2.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "django" },
-    { name = "user-agents" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/9d/2798a8c3a3d900fb7e26dd62c662c7b8ce76f500797712b847984d8704f4/django_boost-2.1.tar.gz", hash = "sha256:a7d8defc2ca0eeebd08636abe58a21094f43fcc7c0ff020f9f8deec82d53a39f", size = 82978, upload-time = "2022-09-07T15:15:09.143Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/bf/c13119bb3746680d3e6812c260e3c8c34c043255f5da7633c6f09c9f1996/django_boost-2.1-py3-none-any.whl", hash = "sha256:c59450d082bb6f7c130d0fcbf5cb9346c183d5d78856966838b17e02901e31b9", size = 232451, upload-time = "2022-09-07T15:15:06.6Z" },
-]
-
-[[package]]
 name = "django-types"
 version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -572,38 +559,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ua-parser"
-version = "1.0.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ua-parser-builtins" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/90/98/5e4b52d772a048af122a6fc5ce365c311efb9f5e79c55fd4fdd7c9f59e83/ua_parser-1.0.2.tar.gz", hash = "sha256:bab404ad42fb37f943107da2f6003ffc79724d11cc95076a7a539513371779da", size = 33239, upload-time = "2026-04-05T20:14:28.229Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/7c/6367995ff57aaa2d9e1055adbaec2519cf5a979780a83a93fdf8c6ec37be/ua_parser-1.0.2-py3-none-any.whl", hash = "sha256:0f8e6d0484af2a9ff804bba5a4fe696e87c028eaba98ad9a7dfae873fef7788a", size = 31219, upload-time = "2026-04-05T20:14:26.913Z" },
-]
-
-[[package]]
-name = "ua-parser-builtins"
-version = "202605"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/42/178db21aab1815583fcdb8ae465fc006b384fbe679412b11ddf8aae90f38/ua_parser_builtins-202605-py3-none-any.whl", hash = "sha256:a86976baa4b7c69a54269fe54091e3f0c7666f15a0f893855ff907a3bb6d878c", size = 90591, upload-time = "2026-05-01T21:25:50.636Z" },
-]
-
-[[package]]
-name = "user-agents"
-version = "2.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ua-parser" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/e1/63c5bfb485a945010c8cbc7a52f85573561737648d36b30394248730a7bc/user-agents-2.2.0.tar.gz", hash = "sha256:d36d25178db65308d1458c5fa4ab39c9b2619377010130329f3955e7626ead26", size = 9525, upload-time = "2020-08-23T06:01:56.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8f/1c/20bb3d7b2bad56d881e3704131ddedbb16eb787101306887dff349064662/user_agents-2.2.0-py3-none-any.whl", hash = "sha256:a98c4dc72ecbc64812c4534108806fb0a0b3a11ec3fd1eafe807cee5b0a942e7", size = 9614, upload-time = "2020-08-23T06:01:54.047Z" },
-]
-
-[[package]]
 name = "virtualenv"
 version = "21.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -627,7 +582,6 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "django-boost" },
     { name = "python-ulid" },
 ]
 
@@ -648,7 +602,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=4.2,<5.0" },
-    { name = "django-boost", marker = "extra == 'all'", specifier = ">=2.1,<3.0" },
     { name = "python-ulid", marker = "extra == 'all'", specifier = ">=3.0,<4.0" },
 ]
 provides-extras = ["all"]

--- a/ya_django_toolkit_jp/base/models/_mixins.py
+++ b/ya_django_toolkit_jp/base/models/_mixins.py
@@ -1,0 +1,38 @@
+"""抽象モデル用の内部 mixin。
+
+旧来は `django_boost.models.mixins.{TimeStampModelMixin, UUIDModelMixin}` を
+利用していたが、django-boost 自体が未保守で Django 5/6 では import 副作用に
+よる詰まりが生じるため、必要な mixin だけ自前再実装してインライン化した。
+
+フィールド定義（列名・型・default・editable・verbose_name 含む）は django_boost
+版と完全に一致させているため、downstream で `AlterField` 差分は出ない。
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class TimeStampModelMixin(models.Model):
+    """`created_at` / `updated_at` フィールドを提供する抽象 mixin。"""
+
+    created_at = models.DateTimeField(
+        verbose_name=_('created date'), auto_now_add=True)
+    updated_at = models.DateTimeField(
+        verbose_name=_('updated date'), auto_now=True)
+
+    class Meta:
+        abstract = True
+
+
+class UUIDModelMixin(models.Model):
+    """主キーを UUID（`uuid4`）に置き換える抽象 mixin。"""
+
+    id = models.UUIDField(default=uuid.uuid4,
+                          primary_key=True, unique=True, editable=False)
+
+    class Meta:
+        abstract = True

--- a/ya_django_toolkit_jp/base/models/base.py
+++ b/ya_django_toolkit_jp/base/models/base.py
@@ -1,4 +1,4 @@
-from django_boost.models.mixins import TimeStampModelMixin
+from ._mixins import TimeStampModelMixin
 
 
 class BaseModel(TimeStampModelMixin):

--- a/ya_django_toolkit_jp/base/models/base_ulid.py
+++ b/ya_django_toolkit_jp/base/models/base_ulid.py
@@ -1,5 +1,4 @@
-from django_boost.models.mixins import TimeStampModelMixin
-
+from ._mixins import TimeStampModelMixin
 from .ulid import ULIDModel
 
 

--- a/ya_django_toolkit_jp/base/models/base_uuid.py
+++ b/ya_django_toolkit_jp/base/models/base_uuid.py
@@ -1,4 +1,4 @@
-from django_boost.models.mixins import TimeStampModelMixin, UUIDModelMixin
+from ._mixins import TimeStampModelMixin, UUIDModelMixin
 
 
 class BaseUUIDModel(TimeStampModelMixin, UUIDModelMixin):


### PR DESCRIPTION
## 概要
Issue #15 の実装。`django-boost` 依存を撤廃し、使用していた 2 mixin（`TimeStampModelMixin` / `UUIDModelMixin`）を自前で再実装してインライン化。

## 変更点

### コード
- 新規 `ya_django_toolkit_jp/base/models/_mixins.py`（内部 mixin）
  - `TimeStampModelMixin`: `created_at` / `updated_at`（`verbose_name=_('created date')` / `_('updated date')` 含む）
  - `UUIDModelMixin`: `id = UUIDField(default=uuid.uuid4, primary_key=True, unique=True, editable=False)`
- `base.py` / `base_uuid.py` / `base_ulid.py` の import 元を `._mixins` へ変更

### 依存
- `pyproject.toml` の `[project.optional-dependencies].all` から `django-boost` を除去（実質 `python-ulid` のみに）
- `uv.lock` から django-boost と推移依存（ua-parser 系）も除外

## 後方互換（ゼロ差分）の実証

別環境で django-boost を入れて `django_boost.models.mixins` の field `deconstruct()` を取得し、本実装と side-by-side で比較。**全フィールドで一致を確認**:

| field | path | kwargs |
|---|---|---|
| `created_at` | `django.db.models.DateTimeField` | `{verbose_name='created date', auto_now_add=True}` |
| `updated_at` | `django.db.models.DateTimeField` | `{verbose_name='updated date', auto_now=True}` |
| `id` (UUID) | `django.db.models.UUIDField` | `{primary_key=True, unique=True, default=<callable: uuid.uuid4>, editable=False, serialize=False}` |

→ downstream の `makemigrations` は `AlterField` を一切生成しない。公開抽象モデル名（`BaseModel` / `BaseUUIDModel` / `BaseULIDModel`）の継承構成も維持。

## ライセンス
django-boost も本プロジェクトも MIT。今回は対象が Django 定型 field 宣言で創作性が低く（de minimis）、かつ自前で再実装している（直接コピペでない）ため、表記保持義務は発生しない。

## 効能
- `django_boost.__init__` の eager import（`EmailUser` 等）が消え、Django 5/6 で `base/models/` が素直に使えるようになる（#13 監査で実証した詰まりが解消）
- これで **Wave 1（基盤＋依存健全化）完了**、#06（nox マトリクス）が技術的に解禁

Closes #15
Refs #06

🤖 Generated with [Claude Code](https://claude.com/claude-code)
