### PR TITLE
chore: .git-blame-ignore-revs に PR #32 の squash hash を追加

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -7,3 +7,9 @@
 
 # style: ruff format で全コードをダブルクォートに統一 (#21 / PR #31 squash)
 0132a6c11be4bd12e6cd184f552dc6c23d76785f
+
+# style: ruff format でシングルクォートへ統一し直す（#21 撤回 / PR #32 squash）
+# ※ クォート反転（~133 行）が大半。utils/file.py の future import 追加と
+#    templatetags の B009/RUF021 refactor（2 行）の実コード変更も含むため、
+#    当該 2 行の blame は本コミットの前へスキップされる点に注意。
+6cef278014baf5606158c4ef1efff8e894212b06


### PR DESCRIPTION
## 概要
PR #32（シングルクォート復帰）の squash 後コミット `6cef278` を blame の無視対象に登録する follow-up。

## 補足
PR #32 の squash は ~133 行のクォート反転に加え、以下の実コード変更も同梱されていた:
- `utils/file.py` の `from __future__ import annotations` 追加（1 行）
- `templatetags/ya_django_toolkit_jp.py` の B009/RUF021 refactor（2 行）

blame skip により当該 3 行の attribution は本コミットの前を指すが、個人 solo OSS の blame 利便性（~133 行のクォート反転を無視できるメリット）を優先した意図的なトレードオフ。PR #32 のレビュー時に確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/yk-lab/ya-django-toolkit-jp/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

